### PR TITLE
www fix 'ReferenceError: event is not defined'

### DIFF
--- a/trunk/user/www/n56u_ribbon_fixed/Advanced_Console_Content.asp
+++ b/trunk/user/www/n56u_ribbon_fixed/Advanced_Console_Content.asp
@@ -61,8 +61,7 @@ function clearOut(){
 }
 
 function checkEnter(e){
-	e = e || event;
-	return (e.keyCode || event.which || event.charCode || 0) === 13;
+	return ((window.event ? window.event.KeyCode : e.which) || event.charCode || 0) === 13;
 }
 </script>
 </head>


### PR DESCRIPTION
www: Advanced_Console_Content: Fix 'ReferenceError: event is not defined', FF and IE need checking whether event is defined.
from: https://bitbucket.org/padavan/rt-n56u/pull-requests/61