### PR TITLE
Dnsmasq strip symbols

### DIFF
--- a/trunk/user/dnsmasq/Makefile
+++ b/trunk/user/dnsmasq/Makefile
@@ -18,4 +18,6 @@ clean:
 	$(MAKE) -C $(SRC_NAME) clean
 
 romfs:
-	$(ROMFSINST) $(SRC_NAME)/src/dnsmasq /usr/sbin/dnsmasq
+	cp $(SRC_NAME)/src/dnsmasq .
+	$(STRIP) dnsmasq
+	$(ROMFSINST) /usr/sbin/dnsmasq


### PR DESCRIPTION
to reduce file size, as the Makefile was 4 years ago: https://github.com/zanezam/padavan-ng/blob/c8cd7e94beabc60aa0f71c5dd48f86716a8f2363/trunk/user/dnsmasq/Makefile

Not tested.