### PR TITLE
remove openssl configure from .gitignore

### DIFF
--- a/trunk/user/openssh/openssh-8.7p1/.gitignore
+++ b/trunk/user/openssh/openssh-8.7p1/.gitignore
@@ -5,7 +5,6 @@ config.h.in
 config.h.in~
 config.log
 config.status
-configure
 aclocal.m4
 openbsd-compat/Makefile
 openbsd-compat/regress/Makefile


### PR DESCRIPTION
autoconf file is needed for building an not auto generated during build process