### PR TITLE
dnsmasq CFLAGS to remove unused code

### DIFF
--- a/trunk/user/dnsmasq/Makefile
+++ b/trunk/user/dnsmasq/Makefile
@@ -12,7 +12,7 @@ COPTS += -DNO_IPSET
 endif
 
 all:
-	$(MAKE) -j$(HOST_NCPU) -C $(SRC_NAME) CFLAGS="$(CFLAGS)" LDFLAGS="$(LDFLAGS)" COPTS="$(COPTS)"
+	$(MAKE) -j$(HOST_NCPU) -C $(SRC_NAME) CFLAGS="$(CFLAGS) -ffunction-sections -fdata-sections" LDFLAGS="$(LDFLAGS) -Wl,--gc-sections" COPTS="$(COPTS)"
 
 clean:
 	$(MAKE) -C $(SRC_NAME) clean


### PR DESCRIPTION
Reduces firmware size by approximately 2 Kb (for version 2.86)